### PR TITLE
Some issues with the new cmake install prefix

### DIFF
--- a/cmake/MainConfig.cmake
+++ b/cmake/MainConfig.cmake
@@ -17,7 +17,7 @@ SET(DEFAULT_LOCATION "$ENV{HOME}/opt")
 #if LONG_PREFIX=on
 IF (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   IF (LONG_PREFIX)
-    SET(PATH_ID "${FC_ID}")
+    SET(PATH_ID "${FC_ID}" CACHE INTERNAL "Default Path ID" FORCE)
     #IF not master branch, include simplified branch name
     IF( (NOT GIT_BRANCH MATCHES "master") )
       SET(PATH_ID  "${PATH_ID}/${GIT_BRANCH}")
@@ -32,7 +32,7 @@ IF (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     SET(MODULE_NAME "${PROJECT_NAME}/${PATH_ID}/${VERSION}")
     SET(FULL_VER "${PATH_ID}/${VERSION}")
   ELSE()
-    SET(PATH_ID "default")
+    SET(PATH_ID "custom" CACHE INTERNAL "Custom Path ID" FORCE)
     #set to $HOME/opt/<libname>
     #set module name accordingly
     SET(DEFAULT_PREFIX "${DEFAULT_LOCATION}/${PROJECT_NAME}/${PATH_ID}")
@@ -40,7 +40,7 @@ IF (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     SET(FULL_VER "${PATH_ID}")
   ENDIF(LONG_PREFIX)
 ELSE()
-  SET(PATH_ID "default")
+  SET(PATH_ID "custom" CACHE INTERNAL "Custom Path ID" FORCE)
   #set to user defined CMAKE_INSTALL_PREFIX
   #set module name accordingly
   SET(DEFAULT_PREFIX "${CMAKE_INSTALL_PREFIX}")

--- a/cmake/MainConfig.cmake
+++ b/cmake/MainConfig.cmake
@@ -30,12 +30,14 @@ IF (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     #set module name accordingly
     SET(DEFAULT_PREFIX "${DEFAULT_LOCATION}/${PROJECT_NAME}/${PATH_ID}/${VERSION}")    
     SET(MODULE_NAME "${PROJECT_NAME}/${PATH_ID}/${VERSION}")
+    SET(FULL_VER "${PATH_ID}/${VERSION}")
   ELSE()
     SET(PATH_ID "default")
     #set to $HOME/opt/<libname>
     #set module name accordingly
     SET(DEFAULT_PREFIX "${DEFAULT_LOCATION}/${PROJECT_NAME}/${PATH_ID}")
     SET(MODULE_NAME "${PROJECT_NAME}/${PATH_ID}")
+    SET(FULL_VER "${PATH_ID}")
   ENDIF(LONG_PREFIX)
 ELSE()
   SET(PATH_ID "default")
@@ -43,6 +45,7 @@ ELSE()
   #set module name accordingly
   SET(DEFAULT_PREFIX "${CMAKE_INSTALL_PREFIX}")
   SET(MODULE_NAME "${PROJECT_NAME}/${PATH_ID}")
+  SET(FULL_VER "${PATH_ID}")
 ENDIF()
 
 

--- a/cmake/PostConfig.cmake
+++ b/cmake/PostConfig.cmake
@@ -18,8 +18,12 @@ set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
 #Create default .version file if following conditions are verified:
 #1. master branch
 #2. no debug
-IF( (NOT "${BUILD_TYPE}" MATCHES "debug") AND (GIT_BRANCH MATCHES "master"))
+IF( (NOT "${BUILD_TYPE}" MATCHES "debug") AND NOT (PATH_ID MATCHES "default") AND (GIT_BRANCH MATCHES "master"))
   SET(TMP_VER_MODULE_FILE ${LIB_TMP_ETC}/modules/${VERSION_PATH}/.version)
+  CONFIGURE_FILE(${LIB_ENV}/version.in ${TMP_VER_MODULE_FILE}  @ONLY)
+  MESSAGE(STATUS "${Red}Version file${ColourReset}: ${TMP_VER_MODULE_FILE}")
+ELSE()
+  SET(TMP_VER_MODULE_FILE ${LIB_TMP_ETC}/modules/${PATH_ID})
   CONFIGURE_FILE(${LIB_ENV}/version.in ${TMP_VER_MODULE_FILE}  @ONLY)
   MESSAGE(STATUS "${Red}Version file${ColourReset}: ${TMP_VER_MODULE_FILE}")
 ENDIF()

--- a/cmake/PostConfig.cmake
+++ b/cmake/PostConfig.cmake
@@ -18,12 +18,8 @@ set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
 #Create default .version file if following conditions are verified:
 #1. master branch
 #2. no debug
-IF( (NOT "${BUILD_TYPE}" MATCHES "debug") AND NOT (PATH_ID MATCHES "default") AND (GIT_BRANCH MATCHES "master"))
+IF( (NOT "${BUILD_TYPE}" MATCHES "debug") AND (NOT "${PATH_ID}" MATCHES "custom") AND (GIT_BRANCH MATCHES "master"))
   SET(TMP_VER_MODULE_FILE ${LIB_TMP_ETC}/modules/${VERSION_PATH}/.version)
-  CONFIGURE_FILE(${LIB_ENV}/version.in ${TMP_VER_MODULE_FILE}  @ONLY)
-  MESSAGE(STATUS "${Red}Version file${ColourReset}: ${TMP_VER_MODULE_FILE}")
-ELSE()
-  SET(TMP_VER_MODULE_FILE ${LIB_TMP_ETC}/modules/${PATH_ID})
   CONFIGURE_FILE(${LIB_ENV}/version.in ${TMP_VER_MODULE_FILE}  @ONLY)
   MESSAGE(STATUS "${Red}Version file${ColourReset}: ${TMP_VER_MODULE_FILE}")
 ENDIF()

--- a/src/singlesite/ED_SETUP.f90
+++ b/src/singlesite/ED_SETUP.f90
@@ -9,7 +9,7 @@ MODULE ED_SETUP
   USE ED_SECTOR
   USE SF_TIMER
   USE SF_PARSE_INPUT, only: delete_input
-  USE SF_IOTOOLS, only:free_unit,reg,file_length
+  USE SF_IOTOOLS, only:free_unit,reg,file_length,txtfy
   USE SF_MISC, only: assert_shape
   USE SF_LINALG, only: eye
 #ifdef _MPI
@@ -208,24 +208,27 @@ contains
     !
     if(MpiMaster)then
        write(LOGfile,"(A)")"Summary:"
-       write(LOGfile,"(A)")"--------------------------------------------"
-       write(LOGfile,"(A,I15)")'# of levels/spin      = ',Ns
-       write(LOGfile,"(A,I15)")'Total size            = ',2*Ns
-       write(LOGfile,"(A,I15)")'# of impurities       = ',Norb
-       write(LOGfile,"(A,I15)")'# of bath/impurity    = ',Nbath
-       write(LOGfile,"(A,I15)")'# of Bath levels/spin = ',Ns-Norb
-       write(LOGfile,"(A,I15)")'# of  sectors         = ',Nsectors
-       write(LOGfile,"(A,I15)")'Ns_Orb                = ',Ns_Orb
-       write(LOGfile,"(A,I15)")'Ns_Ud                 = ',Ns_Ud
-       write(LOGfile,"(A,I15)")'Nph                   = ',Nph
+       write(LOGfile,"(A)")"-----------------------------------------------------"
+       write(LOGfile,"(A,I27)")'# of levels/spin      = ',Ns
+       write(LOGfile,"(A,I27)")'Total size            = ',2*Ns
+       write(LOGfile,"(A,I27)")'# of impurities       = ',Norb
+       write(LOGfile,"(A,I27)")'# of bath/impurity    = ',Nbath
+       write(LOGfile,"(A,I27)")'# of Bath levels/spin = ',Ns-Norb
+       write(LOGfile,"(A,I27)")'# of  sectors         = ',Nsectors
+       write(LOGfile,"(A,I27)")'Ns_Orb                = ',Ns_Orb
+       write(LOGfile,"(A,I27)")'Ns_Ud                 = ',Ns_Ud
+       write(LOGfile,"(A,I27)")'Nph                   = ',Nph
        select case(ed_mode)
        case default
-          write(LOGfile,"(A,"//str(Ns_Ud)//"I8,2X,"//str(Ns_Ud)//"I8,I8,I20)")&
-               'Largest Sector(s)     = ',DimUps,DimDws,DimPh,product(DimUps)*product(DimDws)*DimPh
+          write(LOGfile,"(A)")'Largest Sector(s):'
+          write(LOGfile,"(A,"//str(Ns_Ud)//"A)")' Dim(s) Up            =',(repeat(' ', (28 - Ns_Ud * len_trim(reg(txtfy(DimUps(iorb))))) / Ns_Ud) // reg(txtfy(DimUps(iorb))), iorb=1,Ns_Ud)
+          write(LOGfile,"(A,"//str(Ns_Ud)//"A)")' Dim(s) Up            =',(repeat(' ', (28 - Ns_Ud * len_trim(reg(txtfy(DimUps(iorb))))) / Ns_Ud) // reg(txtfy(DimDws(iorb))), iorb=1,Ns_Ud)
+          write(LOGfile,"(A,A)")                ' Dim(s) Ph            =', repeat(' ', 28 - len_trim(reg(txtfy(DimPh)))) // reg(txtfy(DimPh))
+          write(LOGfile,"(A,A)")                ' Total Dim            =', repeat(' ', 28 - len_trim(reg(txtfy(product(DimUps)*product(DimDws)*DimPh)))) // reg(txtfy(product(DimUps)*product(DimDws)*DimPh))      
        case("superc","nonsu2")
-          write(LOGfile,"(A,I15)")'Largest Sector(s)    = ',dim_sector_max
+          write(LOGfile,"(A,I27)")'Largest Sector(s)     = ',dim_sector_max
        end select
-       write(LOGfile,"(A)")"--------------------------------------------"
+       write(LOGfile,"(A)")"-----------------------------------------------------"
     endif
     !
     allocate(spH0ups(Ns_Ud))


### PR DESCRIPTION
- if long_path is false, cmake tries to create a module directory named "default" in which it puts the module file, which now stays named "module.in". This makes it impossible to load the module. Now it does not create the directory, but renames the module file to "default" instead. It also doesn't create the .version file, since this shouldn't be default I think, being a custom user installation

- for the same reason, replace "default" with "custom" 