### PR TITLE
Bugfix on intel fortran compiler

### DIFF
--- a/src/ineq/E2I_AUX_FUNX.f90
+++ b/src/ineq/E2I_AUX_FUNX.f90
@@ -87,6 +87,9 @@ contains
   !PURPOSE  : Setup Himpurity, the local part of the non-interacting Hamiltonian
   !+------------------------------------------------------------------+
   subroutine ed_set_Hloc_lattice_N2(Hloc,Nlat)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     complex(8),dimension(:,:),intent(in) :: Hloc
     integer                              :: Nlat !Number of impurities for real-space DMFT
     integer                              :: ilat
@@ -124,6 +127,9 @@ contains
 
 
   subroutine ed_set_Hloc_lattice_N3(Hloc,Nlat)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     complex(8),dimension(:,:,:),intent(in) :: Hloc
     integer                                :: Nlat,ilat
 #ifdef _DEBUG
@@ -163,6 +169,9 @@ contains
   end subroutine ed_set_Hloc_lattice_superc_N3
 
   subroutine ed_set_Hloc_lattice_N5(Hloc,Nlat)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     complex(8),dimension(:,:,:,:,:),intent(in) :: Hloc
     integer                                    :: Nlat,ilat
 #ifdef _DEBUG
@@ -197,6 +206,9 @@ contains
 
 
   subroutine set_impHloc(site)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     integer :: site
     if(.not.allocated(Hloc_ineq))stop "set_impHloc error: called with Hloc_ineq not allocated"
     

--- a/src/ineq/E2I_FIT/E2I_FIT_BATH.f90
+++ b/src/ineq/E2I_FIT/E2I_FIT_BATH.f90
@@ -56,6 +56,9 @@ contains
 
 
   subroutine chi2_fitgf_lattice_normal_n3(g,bath,ispin)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     real(8),intent(inout)       :: bath(:,:)
     complex(8),dimension(:,:,:) :: g
     integer,optional            :: ispin
@@ -133,6 +136,9 @@ contains
   end subroutine chi2_fitgf_lattice_normal_n3
 
   subroutine chi2_fitgf_lattice_normal_n4(g,bath,ispin)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     real(8),intent(inout)         :: bath(:,:)
     complex(8),dimension(:,:,:,:) :: g
     integer,optional              :: ispin
@@ -210,6 +216,9 @@ contains
   end subroutine chi2_fitgf_lattice_normal_n4
 
   subroutine chi2_fitgf_lattice_normal_n6(g,bath,ispin)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     real(8),intent(inout)             :: bath(:,:)
     complex(8),dimension(:,:,:,:,:,:) :: g
     integer,optional                  :: ispin
@@ -302,6 +311,9 @@ contains
 
 
   subroutine chi2_fitgf_lattice_superc_n3(g,f,bath,ispin)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     real(8),intent(inout)       :: bath(:,:)
     complex(8),dimension(:,:,:) :: g,f
     integer,optional            :: ispin
@@ -382,6 +394,9 @@ contains
 
 
   subroutine chi2_fitgf_lattice_superc_n4(g,f,bath,ispin)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     real(8),intent(inout)         :: bath(:,:)
     complex(8),dimension(:,:,:,:) :: g,f
     integer,optional              :: ispin
@@ -466,6 +481,9 @@ contains
 
 
   subroutine chi2_fitgf_lattice_superc_n6(g,f,bath,ispin)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     real(8),intent(inout)             :: bath(:,:)
     complex(8),dimension(:,:,:,:,:,:) :: g,f
     integer,optional                  :: ispin

--- a/src/ineq/E2I_IO/get_chi.f90
+++ b/src/ineq/E2I_IO/get_chi.f90
@@ -18,13 +18,13 @@ subroutine ed_get_spinChi_lattice_n3(self,nlat,axis,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,vm)
      case('r','R')
         allocate(z_(lreal))
-        z_(:) = dcmplx(vr(:),eps)
+        z_ = dcmplx(vr,eps)
      case ('t','T')
         allocate(z_(ltau))
-        z_(:) = dcmplx(tau(:),0d0)
+        z_ = dcmplx(tau,0d0)
      end select
   endif
   !
@@ -69,13 +69,13 @@ subroutine ed_get_densChi_lattice_n3(self,nlat,axis,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,vm)
      case('r','R')
         allocate(z_(lreal))
-        z_(:) = dcmplx(vr(:),eps)
+        z_ = dcmplx(vr,eps)
      case ('t','T')
         allocate(z_(ltau))
-        z_(:) = dcmplx(tau(:),0d0)
+        z_ = dcmplx(tau,0d0)
      end select
   endif
   !
@@ -118,13 +118,13 @@ subroutine ed_get_pairChi_lattice_n3(self,nlat,axis,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,vm)
      case('r','R')
         allocate(z_(lreal))
-        z_(:) = dcmplx(vr(:),eps)
+        z_ = dcmplx(vr,eps)
      case ('t','T')
         allocate(z_(ltau))
-        z_(:) = dcmplx(tau(:),0d0)
+        z_ = dcmplx(tau,0d0)
      end select
   endif
   !
@@ -168,13 +168,13 @@ subroutine ed_get_exctChi_lattice_n3(self,nlat,axis,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,vm)
      case('r','R')
         allocate(z_(lreal))
-        z_(:) = dcmplx(vr(:),eps)
+        z_ = dcmplx(vr,eps)
      case ('t','T')
         allocate(z_(ltau))
-        z_(:) = dcmplx(tau(:),0d0)
+        z_ = dcmplx(tau,0d0)
      end select
   endif
   !

--- a/src/ineq/E2I_IO/get_chi.f90
+++ b/src/ineq/E2I_IO/get_chi.f90
@@ -15,13 +15,16 @@ subroutine ed_get_spinChi_lattice_n3(self,nlat,axis,z)
      allocate(z_, source=z)
   else
      select case(axis_)
-     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
+     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,vm))
-     case ('r','R')
-        allocate(z_, source=dcmplx(vr,eps))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
+     case('r','R')
+        allocate(z_(lreal))
+        z_(:) = dcmplx(vr(:),eps)
      case ('t','T')
-      allocate(z_, source=dcmplx(tau,0d0))
+        allocate(z_(ltau))
+        z_(:) = dcmplx(tau(:),0d0)
      end select
   endif
   !
@@ -63,13 +66,16 @@ subroutine ed_get_densChi_lattice_n3(self,nlat,axis,z)
      allocate(z_, source=z)
   else
      select case(axis_)
-     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
+     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,vm))
-     case ('r','R')
-        allocate(z_, source=dcmplx(vr,eps))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
+     case('r','R')
+        allocate(z_(lreal))
+        z_(:) = dcmplx(vr(:),eps)
      case ('t','T')
-      allocate(z_, source=dcmplx(tau,0d0))
+        allocate(z_(ltau))
+        z_(:) = dcmplx(tau(:),0d0)
      end select
   endif
   !
@@ -109,13 +115,16 @@ subroutine ed_get_pairChi_lattice_n3(self,nlat,axis,z)
      allocate(z_, source=z)
   else
      select case(axis_)
-     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
+     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,vm))
-     case ('r','R')
-        allocate(z_, source=dcmplx(vr,eps))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
+     case('r','R')
+        allocate(z_(lreal))
+        z_(:) = dcmplx(vr(:),eps)
      case ('t','T')
-      allocate(z_, source=dcmplx(tau,0d0))
+        allocate(z_(ltau))
+        z_(:) = dcmplx(tau(:),0d0)
      end select
   endif
   !
@@ -156,13 +165,16 @@ subroutine ed_get_exctChi_lattice_n3(self,nlat,axis,z)
      allocate(z_, source=z)
   else
      select case(axis_)
-     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
+     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,vm))
-     case ('r','R')
-        allocate(z_, source=dcmplx(vr,eps))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
+     case('r','R')
+        allocate(z_(lreal))
+        z_(:) = dcmplx(vr(:),eps)
      case ('t','T')
-        allocate(z_, source=dcmplx(tau,0d0))
+        allocate(z_(ltau))
+        z_(:) = dcmplx(tau(:),0d0)
      end select
   endif
   !

--- a/src/ineq/E2I_IO/get_g0imp.f90
+++ b/src/ineq/E2I_IO/get_g0imp.f90
@@ -35,10 +35,10 @@ subroutine ed_get_g0imp_lattice_n3(self,bath,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !
@@ -102,10 +102,10 @@ subroutine ed_get_g0imp_lattice_n4(self,bath,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !
@@ -169,10 +169,10 @@ subroutine ed_get_g0imp_lattice_n6(self,bath,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !

--- a/src/ineq/E2I_IO/get_g0imp.f90
+++ b/src/ineq/E2I_IO/get_g0imp.f90
@@ -34,9 +34,11 @@ subroutine ed_get_g0imp_lattice_n3(self,bath,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -99,9 +101,11 @@ subroutine ed_get_g0imp_lattice_n4(self,bath,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -164,9 +168,11 @@ subroutine ed_get_g0imp_lattice_n6(self,bath,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !

--- a/src/ineq/E2I_IO/get_gimp.f90
+++ b/src/ineq/E2I_IO/get_gimp.f90
@@ -39,10 +39,10 @@ subroutine ed_get_gimp_lattice_n3(self,nlat,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !
@@ -113,10 +113,10 @@ subroutine ed_get_gimp_lattice_n4(self,nlat,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !
@@ -187,10 +187,10 @@ subroutine ed_get_gimp_lattice_n6(self,nlat,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !

--- a/src/ineq/E2I_IO/get_gimp.f90
+++ b/src/ineq/E2I_IO/get_gimp.f90
@@ -38,9 +38,11 @@ subroutine ed_get_gimp_lattice_n3(self,nlat,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -110,9 +112,11 @@ subroutine ed_get_gimp_lattice_n4(self,nlat,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -182,9 +186,11 @@ subroutine ed_get_gimp_lattice_n6(self,nlat,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !

--- a/src/ineq/E2I_IO/get_sigma.f90
+++ b/src/ineq/E2I_IO/get_sigma.f90
@@ -37,10 +37,10 @@ subroutine ed_get_sigma_lattice_n3(self,nlat,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !
@@ -115,10 +115,10 @@ subroutine ed_get_sigma_lattice_n4(self,nlat,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !
@@ -192,10 +192,10 @@ subroutine ed_get_sigma_lattice_n6(self,nlat,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !

--- a/src/ineq/E2I_IO/get_sigma.f90
+++ b/src/ineq/E2I_IO/get_sigma.f90
@@ -36,9 +36,11 @@ subroutine ed_get_sigma_lattice_n3(self,nlat,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -112,9 +114,11 @@ subroutine ed_get_sigma_lattice_n4(self,nlat,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -187,9 +191,11 @@ subroutine ed_get_sigma_lattice_n6(self,nlat,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !

--- a/src/ineq/E2I_MAIN.f90
+++ b/src/ineq/E2I_MAIN.f90
@@ -82,6 +82,9 @@ contains
   !+-----------------------------------------------------------------------------+!
   ! PURPOSE: allocate and initialize one or multiple baths -+!
   subroutine ed_init_solver_lattice(bath)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     real(8),dimension(:,:),intent(inout) :: bath !user bath input array
     integer                              :: ilat,Nineq,Nsectors
     !
@@ -385,6 +388,9 @@ contains
   end subroutine ed_solve_lattice
 
   subroutine ed_solve_lattice_nobath(Nlat,mpi_lanc,Uloc_ii,Ust_ii,Jh_ii,Jp_ii,Jx_ii,flag_gf)
+#if __INTEL_COMPILER
+    use ED_INPUT_VARS, only: Nspin,Norb
+#endif
     integer                                       :: Nlat
     real(8)                                       :: bath_dummy(Nlat,1) !user bath input array
     logical,optional                              :: mpi_lanc  !parallelization strategy flag: if :code:`.false.` each core serially solves an inequivalent site, if :code:`.true.` all cores parallely solve each site in sequence. Default :code:`.false.` .

--- a/src/ineq/EDIPACK2INEQ.f90
+++ b/src/ineq/EDIPACK2INEQ.f90
@@ -40,7 +40,7 @@ MODULE EDIPACK2INEQ
        ed_get_ehartree        , &
        ed_get_eknot           , &
        ed_get_doubles!          , &
-  ! ed_get_sp_dm  
+ ! ed_get_sp_dm  
 
 
   USE E2I_MAIN, only:    &

--- a/src/singlesite/ED_IO/get_chi.f90
+++ b/src/singlesite/ED_IO/get_chi.f90
@@ -19,11 +19,14 @@ subroutine ed_get_spinChi_site_n3(self,axis,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,vm))
-     case ('r','R')
-        allocate(z_, source=dcmplx(vr,eps))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
+     case('r','R')
+        allocate(z_(lreal))
+        z_(:) = dcmplx(vr(:),eps)
      case ('t','T')
-      allocate(z_, source=dcmplx(tau,0d0))
+        allocate(z_(ltau))
+        z_(:) = dcmplx(tau(:),0d0)
      end select
   endif
   !
@@ -55,13 +58,16 @@ subroutine ed_get_densChi_site_n3(self,axis,z)
      allocate(z_, source=z)
   else
      select case(axis_)
-     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
+     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,vm))
-     case ('r','R')
-        allocate(z_, source=dcmplx(vr,eps))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
+     case('r','R')
+        allocate(z_(lreal))
+        z_(:) = dcmplx(vr(:),eps)
      case ('t','T')
-      allocate(z_, source=dcmplx(tau,0d0))
+        allocate(z_(ltau))
+        z_(:) = dcmplx(tau(:),0d0)
      end select
   endif
   !
@@ -93,13 +99,16 @@ subroutine ed_get_pairChi_site_n3(self,axis,z)
      allocate(z_, source=z)
   else
      select case(axis_)
-     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
+     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,vm))
-     case ('r','R')
-        allocate(z_, source=dcmplx(vr,eps))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
+     case('r','R')
+        allocate(z_(lreal))
+        z_(:) = dcmplx(vr(:),eps)
      case ('t','T')
-      allocate(z_, source=dcmplx(tau,0d0))
+        allocate(z_(ltau))
+        z_(:) = dcmplx(tau(:),0d0)
      end select
   endif
   !
@@ -130,13 +139,16 @@ subroutine ed_get_exctChi_site_n3(self,axis,z)
      allocate(z_, source=z)
   else
      select case(axis_)
-     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
+     case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,vm))
-     case ('r','R')
-        allocate(z_, source=dcmplx(vr,eps))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
+     case('r','R')
+        allocate(z_(lreal))
+        z_(:) = dcmplx(vr(:),eps)
      case ('t','T')
-      allocate(z_, source=dcmplx(tau,0d0))
+        allocate(z_(ltau))
+        z_(:) = dcmplx(tau(:),0d0)
      end select
   endif
   !

--- a/src/singlesite/ED_IO/get_chi.f90
+++ b/src/singlesite/ED_IO/get_chi.f90
@@ -20,13 +20,13 @@ subroutine ed_get_spinChi_site_n3(self,axis,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,vm)
      case('r','R')
         allocate(z_(lreal))
-        z_(:) = dcmplx(vr(:),eps)
+        z_ = dcmplx(vr,eps)
      case ('t','T')
         allocate(z_(ltau))
-        z_(:) = dcmplx(tau(:),0d0)
+        z_ = dcmplx(tau,0d0)
      end select
   endif
   !
@@ -61,13 +61,13 @@ subroutine ed_get_densChi_site_n3(self,axis,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,vm)
      case('r','R')
         allocate(z_(lreal))
-        z_(:) = dcmplx(vr(:),eps)
+        z_ = dcmplx(vr,eps)
      case ('t','T')
         allocate(z_(ltau))
-        z_(:) = dcmplx(tau(:),0d0)
+        z_ = dcmplx(tau,0d0)
      end select
   endif
   !
@@ -102,13 +102,13 @@ subroutine ed_get_pairChi_site_n3(self,axis,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,vm)
      case('r','R')
         allocate(z_(lreal))
-        z_(:) = dcmplx(vr(:),eps)
+        z_ = dcmplx(vr,eps)
      case ('t','T')
         allocate(z_(ltau))
-        z_(:) = dcmplx(tau(:),0d0)
+        z_ = dcmplx(tau,0d0)
      end select
   endif
   !
@@ -142,13 +142,13 @@ subroutine ed_get_exctChi_site_n3(self,axis,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis, nor Time"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,vm)
      case('r','R')
         allocate(z_(lreal))
-        z_(:) = dcmplx(vr(:),eps)
+        z_ = dcmplx(vr,eps)
      case ('t','T')
         allocate(z_(ltau))
-        z_(:) = dcmplx(tau(:),0d0)
+        z_ = dcmplx(tau,0d0)
      end select
   endif
   !

--- a/src/singlesite/ED_IO/get_g0imp.f90
+++ b/src/singlesite/ED_IO/get_g0imp.f90
@@ -24,9 +24,11 @@ subroutine ed_get_g0imp_site_n3(self,bath,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(Lreal))
+        z_(:) = dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -71,9 +73,11 @@ subroutine ed_get_g0imp_site_n5(self,bath,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(Lreal))
+        z_(:) = dcmplx(wr(:),eps)
      end select
   endif
   !

--- a/src/singlesite/ED_IO/get_g0imp.f90
+++ b/src/singlesite/ED_IO/get_g0imp.f90
@@ -25,10 +25,10 @@ subroutine ed_get_g0imp_site_n3(self,bath,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(Lreal))
-        z_(:) = dcmplx(wr(:),eps)
+        z_ = dcmplx(wr,eps)
      end select
   endif
   !
@@ -74,10 +74,10 @@ subroutine ed_get_g0imp_site_n5(self,bath,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(Lreal))
-        z_(:) = dcmplx(wr(:),eps)
+        z_ = dcmplx(wr,eps)
      end select
   endif
   !

--- a/src/singlesite/ED_IO/get_gimp.f90
+++ b/src/singlesite/ED_IO/get_gimp.f90
@@ -24,9 +24,11 @@ subroutine ed_get_gimp_site_n3(self,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(Lreal))
+        z_(:) = dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -75,9 +77,11 @@ subroutine ed_get_gimp_site_n5(self,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(Lreal))
+        z_(:) = dcmplx(wr(:),eps)
      end select
   endif
   !

--- a/src/singlesite/ED_IO/get_gimp.f90
+++ b/src/singlesite/ED_IO/get_gimp.f90
@@ -25,10 +25,10 @@ subroutine ed_get_gimp_site_n3(self,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(Lreal))
-        z_(:) = dcmplx(wr(:),eps)
+        z_ = dcmplx(wr,eps)
      end select
   endif
   !
@@ -78,10 +78,10 @@ subroutine ed_get_gimp_site_n5(self,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(Lreal))
-        z_(:) = dcmplx(wr(:),eps)
+        z_ = dcmplx(wr,eps)
      end select
   endif
   !

--- a/src/singlesite/ED_IO/get_sigma.f90
+++ b/src/singlesite/ED_IO/get_sigma.f90
@@ -26,9 +26,11 @@ subroutine ed_get_sigma_site_n3(self,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !
@@ -79,9 +81,11 @@ subroutine ed_get_sigma_site_n5(self,axis,type,z)
      select case(axis_)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
-        allocate(z_, source=dcmplx(0d0,wm))
+        allocate(z_(lmats))
+        z_(:) = dcmplx(0d0,vm(:))
      case ('r','R')
-        allocate(z_, source=dcmplx(wr,eps))
+        allocate(z_(lreal))
+        z_(:)=dcmplx(wr(:),eps)
      end select
   endif
   !

--- a/src/singlesite/ED_IO/get_sigma.f90
+++ b/src/singlesite/ED_IO/get_sigma.f90
@@ -27,10 +27,10 @@ subroutine ed_get_sigma_site_n3(self,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !
@@ -82,10 +82,10 @@ subroutine ed_get_sigma_site_n5(self,axis,type,z)
      case default;stop "ed_get_sigma ERROR: axis is neither Matsubara, nor Realaxis"
      case ('m','M')
         allocate(z_(lmats))
-        z_(:) = dcmplx(0d0,vm(:))
+        z_ = dcmplx(0d0,wm)
      case ('r','R')
         allocate(z_(lreal))
-        z_(:)=dcmplx(wr(:),eps)
+        z_=dcmplx(wr,eps)
      end select
   endif
   !


### PR DESCRIPTION
For reasons yet unknown, ifort/ifx fail dramatically when compiling functions that use allocate(a, source=) in certain conditions. Real frequencies and tau fail, Matsubara frequencies do not. I do not understand the reason for this.

Added usual flags for Nspin,Norb to E2I functions. That was expected.

Testing on machines that use ifort/ifx.